### PR TITLE
fix Segmentation Fault on MacOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
     let samples = (monitoring_duration.as_secs() / sample_interval.as_secs()) as usize;
     
     let mut sys = System::new_all();
-    sys.refresh_components_list();
+    sys.refresh_all();
 
     match command {
         Some("show-temp-files") => {


### PR DESCRIPTION
change sys.efresh_components_list() to sys.refresh_all() to fix Segmentation Fault on MacOS