### PR TITLE
Fix daemon notifications on macOS + read Apple Silicon temperatures (v0.4.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-monitor-rs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["miky rola <mikyrola8@gmail.com>"]
 description = "A lightweight cross-platform system monitoring tool with desktop notifications"
@@ -26,6 +26,10 @@ notify-rust = "4"
 log = "0.4"
 env_logger = "0.11"
 ctrlc = "3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.9"
+core-foundation-sys = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/display.rs
+++ b/src/display.rs
@@ -184,7 +184,15 @@ pub fn display_recommendations(recommendations: &[String]) {
 
 pub fn display_temperature_info(metrics: &SystemMetrics, config: &Config) {
     println!("\n=== Temperature Information ===");
-    
+
+    if metrics.temperature.cpu_temp.is_none()
+        && metrics.temperature.gpu_temp.is_none()
+        && metrics.temperature.components.is_empty()
+    {
+        println!("Temperature data unavailable on this system.");
+        return;
+    }
+
     if let Some(cpu_temp) = &metrics.temperature.cpu_temp {
         println!("CPU Temperature: {:.1}°C / {:.1}°F", 
             cpu_temp.celsius, 

--- a/src/display.rs
+++ b/src/display.rs
@@ -38,7 +38,7 @@ pub fn display_process_summary(sys: &mut System) {
     }
 
     let mut grouped_vec: Vec<_> = grouped_processes.into_iter().collect();
-    grouped_vec.sort_by(|a, b| b.1.1.cmp(&a.1.1));
+    grouped_vec.sort_by_key(|entry| std::cmp::Reverse(entry.1.1));
 
     for (name, (cpu, memory)) in grouped_vec {
         if memory > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod temp_manager;
 mod config;
 mod notifications;
 mod daemon;
+#[cfg(target_os = "macos")]
+mod temperature;
 
 use metrics::collect_system_metrics;
 use types::MetricsScope;
@@ -185,7 +187,7 @@ fn run_clean_temp() {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let cli = Cli::parse();
 
     let mut cfg = config::load(cli.config.as_deref());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,7 +1,9 @@
 use walkdir::WalkDir;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, NetworksExt, ComponentExt};
+use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, NetworksExt};
+#[cfg(not(target_os = "macos"))]
+use sysinfo::ComponentExt;
 use crate::types::{SystemMetrics, DiskMetrics, ProcessMetrics, TempFileMetrics, TempFileInfo, TemperatureMetrics, TemperatureReading, MetricsScope};
 
 pub fn collect_system_metrics(sys: &mut System, scope: MetricsScope) -> SystemMetrics {
@@ -65,29 +67,55 @@ fn create_temp_reading(celsius: f32) -> TemperatureReading {
 }
 
 fn collect_temperature_metrics(sys: &mut System) -> TemperatureMetrics {
-    let mut components = HashMap::new();
+    let components = collect_temperature_components(sys);
 
-    sys.refresh_components();
-    for component in sys.components() {
-        components.insert(
-            component.label().to_string(),
-            create_temp_reading(component.temperature())
-        );
-    }
-
-    let cpu_temp = components.iter()
-        .find(|(label, _)| label.to_lowercase().contains("cpu"))
-        .map(|(_, temp)| temp.clone());
-
-    let gpu_temp = components.iter()
-        .find(|(label, _)| label.to_lowercase().contains("gpu"))
-        .map(|(_, temp)| temp.clone());
+    let cpu_temp = hottest(&components, &["cpu", "pacc", "eacc", "tdie", "soc"]);
+    let gpu_temp = hottest(&components, &["gpu"]);
 
     TemperatureMetrics {
         cpu_temp,
         gpu_temp,
         components,
     }
+}
+
+#[cfg(target_os = "macos")]
+fn collect_temperature_components(_sys: &mut System) -> HashMap<String, TemperatureReading> {
+    crate::temperature::read_sensors()
+        .into_iter()
+        .map(|(label, celsius)| (label, create_temp_reading(celsius)))
+        .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn collect_temperature_components(sys: &mut System) -> HashMap<String, TemperatureReading> {
+    sys.refresh_components();
+    sys.components()
+        .iter()
+        .map(|component| {
+            (
+                component.label().to_string(),
+                create_temp_reading(component.temperature()),
+            )
+        })
+        .collect()
+}
+
+fn hottest(
+    components: &HashMap<String, TemperatureReading>,
+    needles: &[&str],
+) -> Option<TemperatureReading> {
+    let max = components
+        .iter()
+        .filter(|(label, _)| label_contains_any(label, needles))
+        .map(|(_, reading)| reading.celsius)
+        .reduce(f32::max)?;
+    Some(create_temp_reading(max))
+}
+
+fn label_contains_any(label: &str, needles: &[&str]) -> bool {
+    let lower = label.to_lowercase();
+    needles.iter().any(|needle| lower.contains(needle))
 }
 
 fn collect_temp_metrics() -> TempFileMetrics {
@@ -127,10 +155,57 @@ fn collect_temp_metrics() -> TempFileMetrics {
             }
     }
 
-    files.sort_by(|a, b| b.size.cmp(&a.size));
+    files.sort_by_key(|file| std::cmp::Reverse(file.size));
 
     TempFileMetrics {
         total_size,
         files,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn components(entries: &[(&str, f32)]) -> HashMap<String, TemperatureReading> {
+        entries
+            .iter()
+            .map(|(label, celsius)| ((*label).to_string(), create_temp_reading(*celsius)))
+            .collect()
+    }
+
+    #[test]
+    fn temp_reading_converts_to_fahrenheit() {
+        let reading = create_temp_reading(100.0);
+        assert_eq!(reading.celsius, 100.0);
+        assert_eq!(reading.fahrenheit, 212.0);
+    }
+
+    #[test]
+    fn label_matching_is_case_insensitive() {
+        assert!(label_contains_any("pACC MTR Temp Sensor1", &["pacc"]));
+        assert!(label_contains_any("GPU MTR Temp", &["gpu"]));
+        assert!(!label_contains_any("battery", &["cpu", "gpu"]));
+    }
+
+    #[test]
+    fn hottest_picks_max_matching_sensor() {
+        let comps = components(&[
+            ("eACC MTR Temp", 55.0),
+            ("pACC MTR Temp", 72.0),
+            ("GPU MTR Temp", 48.0),
+        ]);
+
+        let cpu = hottest(&comps, &["cpu", "pacc", "eacc", "tdie", "soc"]).unwrap();
+        assert_eq!(cpu.celsius, 72.0);
+
+        let gpu = hottest(&comps, &["gpu"]).unwrap();
+        assert_eq!(gpu.celsius, 48.0);
+    }
+
+    #[test]
+    fn hottest_returns_none_without_match() {
+        let comps = components(&[("battery", 30.0)]);
+        assert!(hottest(&comps, &["cpu", "gpu"]).is_none());
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,9 +1,7 @@
 use walkdir::WalkDir;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, NetworksExt};
-#[cfg(not(target_os = "macos"))]
-use sysinfo::ComponentExt;
+use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, NetworksExt, ComponentExt};
 use crate::types::{SystemMetrics, DiskMetrics, ProcessMetrics, TempFileMetrics, TempFileInfo, TemperatureMetrics, TemperatureReading, MetricsScope};
 
 pub fn collect_system_metrics(sys: &mut System, scope: MetricsScope) -> SystemMetrics {
@@ -80,15 +78,30 @@ fn collect_temperature_metrics(sys: &mut System) -> TemperatureMetrics {
 }
 
 #[cfg(target_os = "macos")]
-fn collect_temperature_components(_sys: &mut System) -> HashMap<String, TemperatureReading> {
-    crate::temperature::read_sensors()
+fn collect_temperature_components(sys: &mut System) -> HashMap<String, TemperatureReading> {
+    let hid: HashMap<String, TemperatureReading> = crate::temperature::read_sensors()
         .into_iter()
         .map(|(label, celsius)| (label, create_temp_reading(celsius)))
-        .collect()
+        .collect();
+    if !hid.is_empty() {
+        return hid;
+    }
+
+    let fallback = sysinfo_temperature_components(sys);
+    if fallback.is_empty() {
+        log::warn!("No temperature sensors available (IOKit HID and sysinfo both returned none)");
+    } else {
+        log::info!("IOKit HID returned no sensors; using sysinfo temperature components");
+    }
+    fallback
 }
 
 #[cfg(not(target_os = "macos"))]
 fn collect_temperature_components(sys: &mut System) -> HashMap<String, TemperatureReading> {
+    sysinfo_temperature_components(sys)
+}
+
+fn sysinfo_temperature_components(sys: &mut System) -> HashMap<String, TemperatureReading> {
     sys.refresh_components();
     sys.components()
         .iter()

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -93,16 +93,47 @@ impl NotificationManager {
     }
 
     fn send_notification(&mut self, title: &str, body: &str, kind: AlertKind) {
-        match notify_rust::Notification::new()
-            .summary(title)
-            .body(body)
-            .show()
-        {
-            Ok(_) => log::info!("Notification sent: {title}"),
+        match deliver_notification(title, body) {
+            Ok(()) => log::info!("Notification sent: {title}"),
             Err(e) => log::warn!("Failed to send notification: {e}"),
         }
         self.last_sent.insert(kind, Instant::now());
     }
+}
+
+#[cfg(target_os = "macos")]
+fn deliver_notification(title: &str, body: &str) -> Result<(), String> {
+    let script = format!(
+        "display notification \"{}\" with title \"{}\"",
+        escape_applescript(body),
+        escape_applescript(title),
+    );
+    let status = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .status()
+        .map_err(|e| e.to_string())?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("osascript exited with {status}"))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn escape_applescript(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn deliver_notification(title: &str, body: &str) -> Result<(), String> {
+    notify_rust::Notification::new()
+        .summary(title)
+        .body(body)
+        .show()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 fn alert_message(kind: &AlertKind, metrics: &SystemMetrics, config: &Config) -> (String, String) {
@@ -300,5 +331,13 @@ mod tests {
         assert_eq!(title, "High Memory Usage");
         assert!(body.contains("85%"));
         assert!(body.contains("80%"), "body was: {body}");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn applescript_escaping_handles_quotes_and_backslashes() {
+        assert_eq!(escape_applescript("plain"), "plain");
+        assert_eq!(escape_applescript(r#"say "hi""#), r#"say \"hi\""#);
+        assert_eq!(escape_applescript(r"a\b"), r"a\\b");
     }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -39,7 +39,23 @@ extern "C" {
     fn IOHIDEventGetFloatValue(event: IOHIDEventRef, field: i32) -> f64;
 }
 
+const READ_ATTEMPTS: usize = 3;
+const RETRY_DELAY_MS: u64 = 50;
+
 pub fn read_sensors() -> HashMap<String, f32> {
+    for attempt in 0..READ_ATTEMPTS {
+        let readings = read_sensors_once();
+        if !readings.is_empty() {
+            return readings;
+        }
+        if attempt + 1 < READ_ATTEMPTS {
+            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
+        }
+    }
+    HashMap::new()
+}
+
+fn read_sensors_once() -> HashMap<String, f32> {
     let mut readings = HashMap::new();
 
     let matching = CFDictionary::from_CFType_pairs(&[

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::os::raw::c_void;
+
+use core_foundation::base::TCFType;
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::string::CFString;
+use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
+use core_foundation_sys::base::{CFRelease, CFTypeRef};
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use core_foundation_sys::string::CFStringRef;
+
+type IOHIDEventSystemClientRef = *mut c_void;
+type IOHIDServiceClientRef = *mut c_void;
+type IOHIDEventRef = *mut c_void;
+
+const PRIMARY_USAGE_PAGE_APPLE_VENDOR: i32 = 0xff00;
+const PRIMARY_USAGE_TEMPERATURE_SENSOR: i32 = 5;
+const EVENT_TYPE_TEMPERATURE: i64 = 15;
+
+#[link(name = "IOKit", kind = "framework")]
+extern "C" {
+    fn IOHIDEventSystemClientCreate(allocator: *const c_void) -> IOHIDEventSystemClientRef;
+    fn IOHIDEventSystemClientSetMatching(
+        client: IOHIDEventSystemClientRef,
+        matching: CFDictionaryRef,
+    ) -> i32;
+    fn IOHIDEventSystemClientCopyServices(client: IOHIDEventSystemClientRef) -> CFArrayRef;
+    fn IOHIDServiceClientCopyProperty(
+        service: IOHIDServiceClientRef,
+        key: CFStringRef,
+    ) -> CFTypeRef;
+    fn IOHIDServiceClientCopyEvent(
+        service: IOHIDServiceClientRef,
+        event_type: i64,
+        options: i64,
+        timeout: i64,
+    ) -> IOHIDEventRef;
+    fn IOHIDEventGetFloatValue(event: IOHIDEventRef, field: i32) -> f64;
+}
+
+pub fn read_sensors() -> HashMap<String, f32> {
+    let mut readings = HashMap::new();
+
+    let matching = CFDictionary::from_CFType_pairs(&[
+        (
+            CFString::new("PrimaryUsagePage").as_CFType(),
+            CFNumber::from(PRIMARY_USAGE_PAGE_APPLE_VENDOR).as_CFType(),
+        ),
+        (
+            CFString::new("PrimaryUsage").as_CFType(),
+            CFNumber::from(PRIMARY_USAGE_TEMPERATURE_SENSOR).as_CFType(),
+        ),
+    ]);
+
+    unsafe {
+        let client = IOHIDEventSystemClientCreate(std::ptr::null());
+        if client.is_null() {
+            return readings;
+        }
+
+        IOHIDEventSystemClientSetMatching(client, matching.as_concrete_TypeRef());
+
+        let services = IOHIDEventSystemClientCopyServices(client);
+        if services.is_null() {
+            CFRelease(client as CFTypeRef);
+            return readings;
+        }
+
+        let count = CFArrayGetCount(services);
+        for index in 0..count {
+            let service = CFArrayGetValueAtIndex(services, index) as IOHIDServiceClientRef;
+            if service.is_null() {
+                continue;
+            }
+
+            if let (Some(name), Some(celsius)) =
+                (service_name(service), service_temperature(service))
+            {
+                if celsius.is_finite() && celsius > 0.0 {
+                    readings.insert(name, celsius);
+                }
+            }
+        }
+
+        CFRelease(services as CFTypeRef);
+        CFRelease(client as CFTypeRef);
+    }
+
+    readings
+}
+
+unsafe fn service_name(service: IOHIDServiceClientRef) -> Option<String> {
+    let key = CFString::new("Product");
+    let value = IOHIDServiceClientCopyProperty(service, key.as_concrete_TypeRef());
+    if value.is_null() {
+        return None;
+    }
+    let name = CFString::wrap_under_create_rule(value as CFStringRef).to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+unsafe fn service_temperature(service: IOHIDServiceClientRef) -> Option<f32> {
+    let event = IOHIDServiceClientCopyEvent(service, EVENT_TYPE_TEMPERATURE, 0, 0);
+    if event.is_null() {
+        return None;
+    }
+    let field = (EVENT_TYPE_TEMPERATURE as i32) << 16;
+    let celsius = IOHIDEventGetFloatValue(event, field) as f32;
+    CFRelease(event as CFTypeRef);
+    Some(celsius)
+}


### PR DESCRIPTION
## Problem
Running `system-monitor daemon` in the background (via `brew services` / launchd) never produced a desktop notification when thresholds were crossed.

Root causes found by investigating the code **and** the running daemon on macOS:

1. **macOS dropped the notifications.** `send_notification` used `notify-rust` → `mac-notification-sys`, which posts through the deprecated `NSUserNotification` API borrowing `com.apple.Terminal`. From a non-bundled binary spawned by launchd, delivery is silently dropped on modern macOS.
2. **The failure was invisible.** `env_logger::init()` defaults to `error`, and the launchd plist sets no `RUST_LOG`, so the "Notification sent" / "Failed to send" lines never appeared — the service log only showed startup banners.
3. **Temperature alerts could never fire on Apple Silicon.** `sysinfo` reports no thermal components on M-series, so `components` was always empty and the temperature threshold compared against 0.

## Changes
- **macOS notifications via `osascript display notification`** (`src/notifications.rs`). `deliver_notification` is platform-split; non-macOS keeps the `notify-rust` path. Title/body are escaped for AppleScript.
- **Apple Silicon temperatures via IOKit HID sensors** (new `src/temperature.rs`). Reads the `IOHIDEventSystemClient` temperature sensors (no root needed) and feeds them into `collect_temperature_metrics`. `cpu_temp`/`gpu_temp` now derive from the hottest matching sensor (handles `pACC`/`eACC`/`tdie`/`soc`/`gpu` labels). Adds macOS-only deps `core-foundation` / `core-foundation-sys`.
- **`env_logger` defaults to `info`** (`src/main.rs`) so the daemon log records send success/failure without needing `RUST_LOG`.
- Version bump **0.3.1 → 0.4.0**.
- Drive-by: fixed two pre-existing `clippy::unnecessary_sort_by` lints (current stable clippy fails CI on them otherwise).

## Verification (on macOS 26.5.1, Apple Silicon)
- `cargo clippy -- -D warnings`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (32 pass incl. new tests), `cargo build --release` — all green.
- One-shot monitor now shows real temps (`CPU Temperature: 42.7°C`, PMU/tdie sensors).
- Ran the daemon with low thresholds: log shows `Notification sent: High CPU Usage / High Memory Usage / High Temperature / High Disk Usage` and the banners appeared. Repeats correctly suppressed by the cooldown.

## Follow-up (post-merge, per discussion)
- Tag `v0.4.0` → release workflow builds artifacts + GitHub Release.
- `cargo publish` for `system-monitor-rs`.
- Update the `miky-rola/homebrew-tap` formula (version + url + sha256), then `brew upgrade system-monitor && brew services restart system-monitor`.