### PR TITLE
Add apply-coolant prompt to throttle hot processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system-monitor-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["miky rola <mikyrola8@gmail.com>"]
 description = "A lightweight cross-platform system monitoring tool with desktop notifications"

--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,26 @@ system-monitor config           # Show config path and current settings
 
 Alerts are delivered through macOS Notification Center. If they don't appear, allow notifications for **Script Editor** in System Settings → Notifications, and make sure Focus / Do Not Disturb is off. On Apple Silicon, CPU/GPU temperatures are read from the built-in thermal sensors — no extra setup needed.
 
+### Apply coolant
+
+When you run `system-monitor` (interactive monitor mode) and a temperature sensor
+is over the configured threshold, it offers to "apply coolant":
+
+```
+Temperature is 92.4°C (over the 80.0°C threshold).
+Apply coolant by lowering priority of the top CPU processes? [y/N]:
+```
+
+Software can't physically cool the chip, so "coolant" means **reducing CPU load**:
+answering `y` lowers the OS scheduling priority of the heaviest CPU-consuming
+processes (`renice` on macOS/Linux, `PriorityClass = Idle` on Windows). This is
+reversible and never kills anything; critical system processes and the monitor
+itself are always skipped. The prompt only appears in interactive mode — the
+background daemon never throttles on its own.
+
+Configure it under `[coolant]` (see below): `enabled`, how many processes to
+target (`top_processes`), and the priority to set (`nice_level`).
+
 ## Running as a service
 
 **macOS (Homebrew):**

--- a/config.example.toml
+++ b/config.example.toml
@@ -20,3 +20,8 @@ cooldown_secs = 300       # minimum seconds between repeat alerts
 
 [daemon]
 check_interval_secs = 60  # how often daemon checks metrics
+
+[coolant]
+enabled = true       # offer to throttle hot processes in interactive monitor mode
+top_processes = 3    # how many top CPU processes to lower priority of
+nice_level = 15      # scheduling priority to set (higher = lower priority)

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub thresholds: ThresholdConfig,
     pub notifications: NotificationConfig,
     pub daemon: DaemonConfig,
+    pub coolant: CoolantConfig,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -43,6 +44,14 @@ pub struct NotificationConfig {
 #[serde(default)]
 pub struct DaemonConfig {
     pub check_interval_secs: u64,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(default)]
+pub struct CoolantConfig {
+    pub enabled: bool,
+    pub top_processes: usize,
+    pub nice_level: i32,
 }
 
 impl Default for MonitoringConfig {
@@ -84,6 +93,16 @@ impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
             check_interval_secs: 60,
+        }
+    }
+}
+
+impl Default for CoolantConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            top_processes: 3,
+            nice_level: 15,
         }
     }
 }
@@ -138,6 +157,11 @@ pub fn display_config(config: &Config) {
     println!();
     println!("[daemon]");
     println!("  check_interval_secs = {}", config.daemon.check_interval_secs);
+    println!();
+    println!("[coolant]");
+    println!("  enabled = {}", config.coolant.enabled);
+    println!("  top_processes = {}", config.coolant.top_processes);
+    println!("  nice_level = {}", config.coolant.nice_level);
 }
 
 #[cfg(test)]
@@ -173,6 +197,11 @@ mod tests {
             daemon: DaemonConfig {
                 check_interval_secs: 60,
             },
+            coolant: CoolantConfig {
+                enabled: true,
+                top_processes: 3,
+                nice_level: 15,
+            },
         });
     }
 
@@ -189,6 +218,7 @@ cpu_percent = 75.0
         assert_eq!(config.monitoring, MonitoringConfig::default());
         assert_eq!(config.notifications, NotificationConfig::default());
         assert_eq!(config.daemon, DaemonConfig::default());
+        assert_eq!(config.coolant, CoolantConfig::default());
     }
 
     #[test]
@@ -216,6 +246,11 @@ cooldown_secs = 600
 
 [daemon]
 check_interval_secs = 120
+
+[coolant]
+enabled = false
+top_processes = 5
+nice_level = 10
 "#;
         let config: Config = toml::from_str(toml_content).unwrap();
 
@@ -242,6 +277,11 @@ check_interval_secs = 120
             },
             daemon: DaemonConfig {
                 check_interval_secs: 120,
+            },
+            coolant: CoolantConfig {
+                enabled: false,
+                top_processes: 5,
+                nice_level: 10,
             },
         });
     }

--- a/src/coolant.rs
+++ b/src/coolant.rs
@@ -1,0 +1,175 @@
+use std::process::Command;
+use sysinfo::PidExt;
+use crate::config::CoolantConfig;
+use crate::types::ProcessMetrics;
+
+const CRITICAL_PROCESSES: &[&str] = &[
+    "kernel_task",
+    "launchd",
+    "windowserver",
+    "systemd",
+    "init",
+    "csrss.exe",
+    "wininit.exe",
+    "services.exe",
+    "system",
+];
+
+const MIN_CPU_PERCENT: f32 = 1.0;
+
+pub struct CoolantReport {
+    pub cooled: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+pub fn select_targets<'a>(
+    processes: &'a [ProcessMetrics],
+    cfg: &CoolantConfig,
+) -> Vec<&'a ProcessMetrics> {
+    let self_pid = std::process::id();
+    let mut candidates: Vec<&ProcessMetrics> = processes
+        .iter()
+        .filter(|process| {
+            let pid = process.pid.as_u32();
+            let name = process.name.to_lowercase();
+            process.cpu_usage > MIN_CPU_PERCENT
+                && pid != self_pid
+                && pid != 0
+                && pid != 1
+                && !CRITICAL_PROCESSES.contains(&name.as_str())
+        })
+        .collect();
+    candidates.sort_by(|a, b| b.cpu_usage.total_cmp(&a.cpu_usage));
+    candidates.truncate(cfg.top_processes);
+    candidates
+}
+
+pub fn lower_priority(pid: sysinfo::Pid, nice_level: i32) -> Result<(), String> {
+    let raw = pid.as_u32();
+
+    #[cfg(unix)]
+    let output = Command::new("renice")
+        .args([nice_level.to_string(), "-p".to_string(), raw.to_string()])
+        .output();
+
+    #[cfg(windows)]
+    let output = {
+        let _ = nice_level;
+        Command::new("powershell")
+            .args([
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                format!("(Get-Process -Id {raw}).PriorityClass='Idle'"),
+            ])
+            .output()
+    };
+
+    match output {
+        Ok(result) if result.status.success() => Ok(()),
+        Ok(result) => {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            let message = stderr.trim();
+            if message.is_empty() {
+                Err(format!("exited with {}", result.status))
+            } else {
+                Err(message.to_string())
+            }
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn apply_coolant(targets: &[&ProcessMetrics], cfg: &CoolantConfig) -> CoolantReport {
+    let mut cooled = Vec::new();
+    let mut errors = Vec::new();
+
+    for target in targets {
+        let label = format!("{} (pid {})", target.name, target.pid.as_u32());
+        match lower_priority(target.pid, cfg.nice_level) {
+            Ok(()) => cooled.push(label),
+            Err(error) => errors.push(format!("{label}: {error}")),
+        }
+    }
+
+    CoolantReport { cooled, errors }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn process(name: &str, pid: usize, cpu_usage: f32) -> ProcessMetrics {
+        ProcessMetrics {
+            name: name.to_string(),
+            pid: sysinfo::Pid::from(pid),
+            cpu_usage,
+            memory_usage: 0,
+            disk_usage: 0,
+        }
+    }
+
+    fn target_pids(targets: &[&ProcessMetrics]) -> Vec<u32> {
+        targets.iter().map(|process| process.pid.as_u32()).collect()
+    }
+
+    fn config(top_processes: usize) -> CoolantConfig {
+        CoolantConfig {
+            enabled: true,
+            top_processes,
+            nice_level: 15,
+        }
+    }
+
+    #[test]
+    fn selects_top_cpu_processes_in_descending_order() {
+        let processes = vec![
+            process("light", 100, 5.0),
+            process("hottest", 101, 90.0),
+            process("medium", 102, 40.0),
+        ];
+
+        let targets = select_targets(&processes, &config(2));
+
+        assert_eq!(target_pids(&targets), vec![101, 102]);
+    }
+
+    #[test]
+    fn skips_processes_below_cpu_floor() {
+        let processes = vec![
+            process("idle", 200, 0.5),
+            process("busy", 201, 12.0),
+        ];
+
+        let targets = select_targets(&processes, &config(5));
+
+        assert_eq!(target_pids(&targets), vec![201]);
+    }
+
+    #[test]
+    fn excludes_critical_processes_and_low_pids() {
+        let processes = vec![
+            process("launchd", 50, 99.0),
+            process("WindowServer", 51, 95.0),
+            process("init", 0, 80.0),
+            process("kernel_task", 1, 70.0),
+            process("user-app", 300, 60.0),
+        ];
+
+        let targets = select_targets(&processes, &config(10));
+
+        assert_eq!(target_pids(&targets), vec![300]);
+    }
+
+    #[test]
+    fn excludes_our_own_process() {
+        let self_pid = std::process::id() as usize;
+        let processes = vec![
+            process("system-monitor", self_pid, 99.0),
+            process("other", self_pid + 1, 50.0),
+        ];
+
+        let targets = select_targets(&processes, &config(10));
+
+        assert_eq!(target_pids(&targets), vec![(self_pid + 1) as u32]);
+    }
+}

--- a/src/coolant.rs
+++ b/src/coolant.rs
@@ -48,9 +48,13 @@ pub fn lower_priority(pid: sysinfo::Pid, nice_level: i32) -> Result<(), String> 
     let raw = pid.as_u32();
 
     #[cfg(unix)]
-    let output = Command::new("renice")
-        .args([nice_level.to_string(), "-p".to_string(), raw.to_string()])
-        .output();
+    let output = {
+        // Coolant only lowers priority; clamp so a negative value can't raise it.
+        let level = nice_level.clamp(0, 19);
+        Command::new("renice")
+            .args([level.to_string(), "-p".to_string(), raw.to_string()])
+            .output()
+    };
 
     #[cfg(windows)]
     let output = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,9 @@ fn run_monitor(cfg: &config::Config) {
             if max_temp > cfg.thresholds.temperature_celsius as f32
                 && prompt_apply_coolant(max_temp, cfg.thresholds.temperature_celsius)
             {
-                let targets = coolant::select_targets(&last_metrics.process_metrics, &cfg.coolant);
+                sys.refresh_processes();
+                let fresh_processes = metrics::collect_process_metrics(&mut sys);
+                let targets = coolant::select_targets(&fresh_processes, &cfg.coolant);
                 if targets.is_empty() {
                     println!("No throttleable processes found — nothing to cool.");
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::thread;
 use std::path::Path;
 use std::io::{self, Write};
 use clap::{Parser, Subcommand};
-use sysinfo::{System, SystemExt};
+use sysinfo::{System, SystemExt, PidExt};
 
 mod metrics;
 mod analysis;
@@ -14,6 +14,7 @@ mod temp_manager;
 mod config;
 mod notifications;
 mod daemon;
+mod coolant;
 #[cfg(target_os = "macos")]
 mod temperature;
 
@@ -94,6 +95,16 @@ fn prompt_temp_file_age() -> Option<u64> {
     }
 }
 
+fn prompt_apply_coolant(temp: f32, threshold: f64) -> bool {
+    println!("\nTemperature is {temp:.1}°C (over the {threshold:.1}°C threshold).");
+    print!("Apply coolant by lowering priority of the top CPU processes? [y/N]: ");
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
 fn run_monitor(cfg: &config::Config) {
     let monitoring_duration = Duration::from_secs(cfg.monitoring.duration_secs);
     let sample_interval = Duration::from_secs(cfg.monitoring.sample_interval_secs);
@@ -136,6 +147,52 @@ fn run_monitor(cfg: &config::Config) {
         if let Some(last_metrics) = metrics_history.last() {
             let mut notifier = notifications::NotificationManager::new(cfg.notifications.cooldown_secs);
             notifier.check_and_notify(last_metrics, cfg);
+        }
+    }
+
+    if cfg.coolant.enabled {
+        if let Some(last_metrics) = metrics_history.last() {
+            let max_temp = last_metrics
+                .temperature
+                .components
+                .values()
+                .map(|reading| reading.celsius)
+                .fold(f32::NEG_INFINITY, f32::max)
+                .max(
+                    last_metrics
+                        .temperature
+                        .cpu_temp
+                        .as_ref()
+                        .map(|reading| reading.celsius)
+                        .unwrap_or(f32::NEG_INFINITY),
+                );
+
+            if max_temp > cfg.thresholds.temperature_celsius as f32
+                && prompt_apply_coolant(max_temp, cfg.thresholds.temperature_celsius)
+            {
+                let targets = coolant::select_targets(&last_metrics.process_metrics, &cfg.coolant);
+                if targets.is_empty() {
+                    println!("No throttleable processes found — nothing to cool.");
+                } else {
+                    println!("\nLowering priority of:");
+                    for target in &targets {
+                        println!(
+                            "  {} (pid {}) — {:.1}% CPU",
+                            target.name,
+                            target.pid.as_u32(),
+                            target.cpu_usage
+                        );
+                    }
+
+                    let report = coolant::apply_coolant(&targets, &cfg.coolant);
+                    for cooled in &report.cooled {
+                        println!("  cooled: {cooled}");
+                    }
+                    for error in &report.errors {
+                        println!("  failed: {error}");
+                    }
+                }
+            }
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -44,7 +44,7 @@ fn collect_disk_metrics(sys: &mut System) -> HashMap<String, DiskMetrics> {
     metrics
 }
 
-fn collect_process_metrics(sys: &mut System) -> Vec<ProcessMetrics> {
+pub fn collect_process_metrics(sys: &mut System) -> Vec<ProcessMetrics> {
     sys.processes()
         .values()
         .map(|process| ProcessMetrics {


### PR DESCRIPTION
## What & why

Software can't physically cool a chip, so the realistic lever for an overheating
machine is to **reduce CPU load**. This adds an "apply coolant" prompt: when an
interactive `system-monitor` run finds a temperature sensor over the configured
threshold, it offers to lower the OS scheduling priority of the heaviest
CPU-consuming processes.

```
Temperature is 92.4°C (over the 80.0°C threshold).
Apply coolant by lowering priority of the top CPU processes? [y/N]:
```

On `y` it renices the top CPU hogs — `renice` on macOS/Linux, `PriorityClass = Idle`
(PowerShell) on Windows. It's reversible, never kills anything, and always skips
critical system processes (`launchd`, `WindowServer`, `systemd`, pids 0/1, …) and
the monitor itself.

## Design

- **Action = renice**, not pause/kill — low-risk and reversible.
- **Interactive `monitor` mode only.** The headless daemon is untouched: macOS
  `osascript` notifications can't capture a button click and the daemon has no
  stdin. Unattended machines therefore won't auto-throttle (possible follow-up:
  a daemon auto-apply mode).

## Changes

- `src/coolant.rs` — new module: `select_targets`, `lower_priority` (per-OS),
  `apply_coolant`, + 4 unit tests.
- `src/config.rs` — `[coolant]` config (`enabled`/`top_processes`/`nice_level`,
  defaults `true`/`3`/`15`).
- `src/main.rs` — `prompt_apply_coolant` + trigger in `run_monitor`.
- `README.MD`, `config.example.toml` — docs.
- `Cargo.toml` — version `0.4.0` → `0.4.1`.

## Verification

- `cargo clippy --all-targets` clean; **36 tests pass** (4 new coolant tests).
- End-to-end with a forced low threshold: **N** → prompt shown, nothing touched;
  **Y** → two real CPU-hog processes went from nice 5 → 15.
