### PR TITLE
Bound temp file retention and audit resource cleanup

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -42,16 +42,21 @@ pub fn analyze_memory_trend(metrics_history: &[SystemMetrics]) -> UsageTrend {
 }
 
 pub fn analyze_network_trend(metrics_history: &[SystemMetrics]) -> NetworkTrend {
-    let duration = metrics_history.last().unwrap().timestamp
-        .duration_since(metrics_history[0].timestamp)
-        .as_secs_f64();
+    let elapsed = match (metrics_history.first(), metrics_history.last()) {
+        (Some(first), Some(last)) => last.timestamp.duration_since(first.timestamp).as_secs_f64(),
+        (Some(_), None) | (None, Some(_)) | (None, None) => 0.0,
+    };
+
+    if elapsed <= 0.0 {
+        return NetworkTrend { rx_rate: 0.0, tx_rate: 0.0 };
+    }
 
     let total_rx: u64 = metrics_history.iter().map(|m| m.network_rx).sum();
     let total_tx: u64 = metrics_history.iter().map(|m| m.network_tx).sum();
 
     NetworkTrend {
-        rx_rate: total_rx as f64 / duration,
-        tx_rate: total_tx as f64 / duration,
+        rx_rate: total_rx as f64 / elapsed,
+        tx_rate: total_tx as f64 / elapsed,
     }
 }
 
@@ -95,5 +100,63 @@ fn calculate_usage_pattern(values: &[f32]) -> f64 {
         0.0
     } else {
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{TempFileMetrics, TemperatureMetrics};
+    use std::collections::HashMap;
+    use std::time::Instant;
+
+    fn make_metrics(rx: u64, tx: u64) -> SystemMetrics {
+        SystemMetrics {
+            timestamp: Instant::now(),
+            cpu_usage: vec![10.0],
+            memory_usage: 50,
+            memory_total: 100,
+            swap_usage: 0,
+            swap_total: 0,
+            network_rx: rx,
+            network_tx: tx,
+            disk_usage: HashMap::new(),
+            process_metrics: Vec::new(),
+            temp_files: TempFileMetrics::default(),
+            temperature: TemperatureMetrics {
+                cpu_temp: None,
+                gpu_temp: None,
+                components: HashMap::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn network_trend_is_zero_for_empty_history() {
+        assert_eq!(
+            analyze_network_trend(&[]),
+            NetworkTrend { rx_rate: 0.0, tx_rate: 0.0 }
+        );
+    }
+
+    #[test]
+    fn network_trend_is_zero_for_single_sample() {
+        assert_eq!(
+            analyze_network_trend(&[make_metrics(1000, 500)]),
+            NetworkTrend { rx_rate: 0.0, tx_rate: 0.0 }
+        );
+    }
+
+    #[test]
+    fn network_trend_is_finite_across_elapsed_samples() {
+        let first = make_metrics(1000, 500);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let second = make_metrics(1000, 500);
+
+        let trend = analyze_network_trend(&[first, second]);
+
+        assert!(trend.rx_rate.is_finite() && trend.rx_rate > 0.0);
+        assert!(trend.tx_rate.is_finite() && trend.tx_rate > 0.0);
+        assert!(trend.rx_rate > trend.tx_rate);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -93,7 +93,7 @@ mod tests {
             network_tx: 0,
             disk_usage: HashMap::new(),
             process_metrics: Vec::new(),
-            temp_files: TempFileMetrics { total_size: 0, files: Vec::new() },
+            temp_files: TempFileMetrics::default(),
             temperature: TemperatureMetrics {
                 cpu_temp: None,
                 gpu_temp: None,

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use sysinfo::{System, SystemExt, ProcessExt, CpuExt};
 use humansize::{format_size, BINARY};
-use crate::types::{SystemMetrics, SecurityAnalysis};
+use crate::types::{SystemMetrics, SecurityAnalysis, TempFileMetrics};
 use crate::config::Config;
 use crate::analysis::{analyze_cpu_trend, analyze_memory_trend, analyze_network_trend, classify_usage_pattern};
 
@@ -69,17 +69,17 @@ pub fn display_system_info(sys: &System) {
              sys.cpus().len());
 }
 
-pub fn display_temp_files(metrics: &SystemMetrics) {
+pub fn display_temp_files(temp_files: &TempFileMetrics) {
     println!("\n=== Temporary Files Analysis ===");
-    println!("Total Size: {}", format_size(metrics.temp_files.total_size, BINARY));
-    println!("Total Files: {}", metrics.temp_files.files.len());
-    
-    if !metrics.temp_files.files.is_empty() {
+    println!("Total Size: {}", format_size(temp_files.total_size, BINARY));
+    println!("Total Files: {}", temp_files.file_count);
+
+    if !temp_files.files.is_empty() {
         println!("\nAll Temporary Files:");
         println!("{:<10} {:<20} Path", "Size", "Last Modified");
         println!("{:-<80}", "");
         
-        for file in &metrics.temp_files.files {
+        for file in &temp_files.files {
             let last_modified = file.last_modified
                 .map(|time| {
                     time.duration_since(std::time::UNIX_EPOCH)
@@ -136,11 +136,10 @@ pub fn display_performance_analysis(metrics_history: &[SystemMetrics]) {
              format_size(network_trend.rx_rate as u64, BINARY),
              format_size(network_trend.tx_rate as u64, BINARY));
 
-    // Just show summary of temp files
     let latest_metrics = metrics_history.last().unwrap();
     println!("\nTemporary Files Summary:");
     println!("Total Size: {}", format_size(latest_metrics.temp_files.total_size, BINARY));
-    println!("Total Files: {}", latest_metrics.temp_files.files.len());
+    println!("Total Files: {}", latest_metrics.temp_files.file_count);
     println!("Use 'show-temp-files' command to view detailed listing");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 use std::thread;
-use std::path::Path;
 use std::io::{self, Write};
 use clap::{Parser, Subcommand};
 use sysinfo::{System, SystemExt, PidExt};
@@ -107,8 +106,8 @@ fn prompt_apply_coolant(temp: f32, threshold: f64) -> bool {
 
 fn run_monitor(cfg: &config::Config) {
     let monitoring_duration = Duration::from_secs(cfg.monitoring.duration_secs);
-    let sample_interval = Duration::from_secs(cfg.monitoring.sample_interval_secs);
-    let samples = (monitoring_duration.as_secs() / sample_interval.as_secs()) as usize;
+    let sample_interval = Duration::from_secs(cfg.monitoring.sample_interval_secs.max(1));
+    let samples = ((monitoring_duration.as_secs() / sample_interval.as_secs()) as usize).max(1);
 
     let mut sys = System::new_all();
     #[cfg(target_os = "macos")]
@@ -119,9 +118,14 @@ fn run_monitor(cfg: &config::Config) {
     println!("Collecting system metrics over {} seconds...", monitoring_duration.as_secs());
     display_process_summary(&mut sys);
 
-    let mut metrics_history = Vec::new();
+    let mut metrics_history = Vec::with_capacity(samples);
     for i in 0..samples {
-        metrics_history.push(collect_system_metrics(&mut sys, MetricsScope::Full));
+        let scope = if i + 1 == samples {
+            MetricsScope::Summary
+        } else {
+            MetricsScope::Light
+        };
+        metrics_history.push(collect_system_metrics(&mut sys, scope));
 
         if i < samples - 1 {
             print!(".");
@@ -206,15 +210,9 @@ fn run_monitor(cfg: &config::Config) {
 }
 
 fn run_show_temp_files() {
-    let mut sys = System::new_all();
-    #[cfg(target_os = "macos")]
-    sys.refresh_all();
-    #[cfg(not(target_os = "macos"))]
-    sys.refresh_components_list();
-
     println!("Collecting temporary file information...");
-    let metrics = collect_system_metrics(&mut sys, MetricsScope::Full);
-    display_temp_files(&metrics);
+    let temp_files = metrics::collect_temp_files(MetricsScope::Full);
+    display_temp_files(&temp_files);
 }
 
 fn run_clean_temp() {
@@ -224,14 +222,7 @@ fn run_clean_temp() {
     };
 
     println!("\nCleaning temporary files...");
-    let temp_dir = std::env::temp_dir();
-    let temp_paths: Vec<&Path> = vec![
-        temp_dir.as_path(),
-        Path::new("/tmp"),
-        Path::new("/var/tmp"),
-    ];
-
-    let stats = delete_temp_files(&temp_paths, days_threshold);
+    let stats = delete_temp_files(&temp_manager::temp_roots(), days_threshold);
 
     println!("\nCleanup Results:");
     println!("Files Deleted: {}", stats.files_deleted);
@@ -241,6 +232,9 @@ fn run_clean_temp() {
         println!("\nErrors encountered:");
         for error in &stats.errors {
             println!("- {error}");
+        }
+        if stats.errors_omitted > 0 {
+            println!("- ...and {} more", stats.errors_omitted);
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,10 +5,7 @@ use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, Networ
 use crate::types::{SystemMetrics, DiskMetrics, ProcessMetrics, TempFileMetrics, TempFileInfo, TemperatureMetrics, TemperatureReading, MetricsScope};
 
 pub fn collect_system_metrics(sys: &mut System, scope: MetricsScope) -> SystemMetrics {
-    let temp_files = match scope {
-        MetricsScope::Full => collect_temp_metrics(),
-        MetricsScope::Light => TempFileMetrics { total_size: 0, files: Vec::new() },
-    };
+    let temp_files = collect_temp_files(scope);
 
     SystemMetrics {
         timestamp: std::time::Instant::now(),
@@ -131,49 +128,50 @@ fn label_contains_any(label: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| lower.contains(needle))
 }
 
-fn collect_temp_metrics() -> TempFileMetrics {
-    let mut total_size = 0u64;
-    let mut files = Vec::new();
+pub fn collect_temp_files(scope: MetricsScope) -> TempFileMetrics {
+    scan_temp_roots(&crate::temp_manager::temp_roots(), scope)
+}
 
-    let temp_paths = vec![
-        std::env::temp_dir(),
-        PathBuf::from("/tmp"),
-        PathBuf::from("/var/tmp"),
-        PathBuf::from(format!("{}\\AppData\\Local\\Temp",
-            std::env::var("USERPROFILE").unwrap_or_default())),
-    ];
+fn scan_temp_roots(roots: &[PathBuf], scope: MetricsScope) -> TempFileMetrics {
+    match scope {
+        MetricsScope::Full | MetricsScope::Summary => {}
+        MetricsScope::Light => return TempFileMetrics::default(),
+    }
 
-    for temp_path in temp_paths {
-        if !temp_path.exists() {
-            continue;
-        }
+    let mut metrics = TempFileMetrics::default();
 
-        for entry in WalkDir::new(temp_path)
+    for root in roots {
+        for entry in WalkDir::new(root)
             .min_depth(1)
             .follow_links(false)
             .into_iter()
-            .filter_map(|e| e.ok()) {
-                if let Ok(metadata) = entry.metadata() {
-                    if metadata.is_file() {
-                        let size = metadata.len();
-                        total_size += size;
-
-                        files.push(TempFileInfo {
-                            path: entry.path().to_string_lossy().into_owned(),
-                            size,
-                            last_modified: metadata.modified().ok(),
-                        });
-                    }
-                }
+            .filter_map(Result::ok)
+        {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
             }
+
+            let size = metadata.len();
+            metrics.total_size = metrics.total_size.saturating_add(size);
+            metrics.file_count += 1;
+
+            match scope {
+                MetricsScope::Full => metrics.files.push(TempFileInfo {
+                    path: entry.path().to_string_lossy().into_owned(),
+                    size,
+                    last_modified: metadata.modified().ok(),
+                }),
+                MetricsScope::Summary | MetricsScope::Light => {}
+            }
+        }
     }
 
-    files.sort_by_key(|file| std::cmp::Reverse(file.size));
+    metrics.files.sort_by_key(|file| std::cmp::Reverse(file.size));
 
-    TempFileMetrics {
-        total_size,
-        files,
-    }
+    metrics
 }
 
 #[cfg(test)]
@@ -220,5 +218,52 @@ mod tests {
     fn hottest_returns_none_without_match() {
         let comps = components(&[("battery", 30.0)]);
         assert!(hottest(&comps, &["cpu", "gpu"]).is_none());
+    }
+
+    fn temp_root_with_files() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("small.tmp"), vec![0u8; 10]).unwrap();
+        std::fs::write(dir.path().join("large.tmp"), vec![0u8; 100]).unwrap();
+        dir
+    }
+
+    #[test]
+    fn light_scope_scans_nothing() {
+        let dir = temp_root_with_files();
+
+        let metrics = scan_temp_roots(&[dir.path().to_path_buf()], MetricsScope::Light);
+
+        assert_eq!(metrics, TempFileMetrics::default());
+    }
+
+    #[test]
+    fn summary_scope_counts_without_retaining_paths() {
+        let dir = temp_root_with_files();
+
+        let metrics = scan_temp_roots(&[dir.path().to_path_buf()], MetricsScope::Summary);
+
+        assert_eq!(
+            metrics,
+            TempFileMetrics {
+                total_size: 110,
+                file_count: 2,
+                files: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn full_scope_retains_paths_largest_first() {
+        let dir = temp_root_with_files();
+
+        let metrics = scan_temp_roots(&[dir.path().to_path_buf()], MetricsScope::Full);
+
+        assert_eq!(metrics.total_size, 110);
+        assert_eq!(metrics.file_count, 2);
+        assert_eq!(
+            metrics.files.iter().map(|file| file.size).collect::<Vec<_>>(),
+            vec![100, 10]
+        );
+        assert!(metrics.files[0].path.ends_with("large.tmp"));
     }
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -188,7 +188,7 @@ mod tests {
             network_tx: 0,
             disk_usage: HashMap::new(),
             process_metrics: Vec::new(),
-            temp_files: TempFileMetrics { total_size: 0, files: Vec::new() },
+            temp_files: TempFileMetrics::default(),
             temperature: TemperatureMetrics {
                 cpu_temp: None,
                 gpu_temp: None,

--- a/src/security.rs
+++ b/src/security.rs
@@ -167,7 +167,7 @@ mod tests {
             network_tx: 0,
             disk_usage: HashMap::new(),
             process_metrics: Vec::new(),
-            temp_files: TempFileMetrics { total_size: 0, files: Vec::new() },
+            temp_files: TempFileMetrics::default(),
             temperature: TemperatureMetrics {
                 cpu_temp: None,
                 gpu_temp: None,

--- a/src/temp_manager.rs
+++ b/src/temp_manager.rs
@@ -1,68 +1,187 @@
 use std::fs;
-use std::path::Path;
-// use std::io;
+use std::path::PathBuf;
 use walkdir::WalkDir;
 
+const MAX_REPORTED_ERRORS: usize = 50;
+
+#[derive(Debug, Default, PartialEq)]
 pub struct TempCleanupStats {
     pub files_deleted: usize,
     pub bytes_freed: u64,
     pub errors: Vec<String>,
+    pub errors_omitted: usize,
 }
 
-pub fn delete_temp_files(paths: &[&Path], min_days_old: u64) -> TempCleanupStats {
-    let mut stats = TempCleanupStats {
-        files_deleted: 0,
-        bytes_freed: 0,
-        errors: Vec::new(),
-    };
+impl TempCleanupStats {
+    fn record_error(&mut self, message: String) {
+        if self.errors.len() < MAX_REPORTED_ERRORS {
+            self.errors.push(message);
+        } else {
+            self.errors_omitted += 1;
+        }
+    }
+}
 
-    let current_time = std::time::SystemTime::now();
-    
-    for &path in paths {
-        if !path.exists() {
+pub fn temp_roots() -> Vec<PathBuf> {
+    let mut candidates = vec![
+        std::env::temp_dir(),
+        PathBuf::from("/tmp"),
+        PathBuf::from("/var/tmp"),
+    ];
+    candidates.extend(user_profile_temp_root());
+
+    dedup_roots(candidates)
+}
+
+#[cfg(windows)]
+fn user_profile_temp_root() -> Option<PathBuf> {
+    std::env::var("USERPROFILE")
+        .ok()
+        .map(|profile| PathBuf::from(profile).join("AppData").join("Local").join("Temp"))
+}
+
+#[cfg(not(windows))]
+fn user_profile_temp_root() -> Option<PathBuf> {
+    None
+}
+
+fn dedup_roots(candidates: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+
+    for candidate in candidates {
+        let Ok(canonical) = candidate.canonicalize() else {
+            continue;
+        };
+        if !canonical.is_dir() || roots.iter().any(|root| canonical.starts_with(root)) {
             continue;
         }
+        roots.retain(|root| !root.starts_with(&canonical));
+        roots.push(canonical);
+    }
 
+    roots
+}
+
+pub fn delete_temp_files(paths: &[PathBuf], min_days_old: u64) -> TempCleanupStats {
+    let mut stats = TempCleanupStats::default();
+    let current_time = std::time::SystemTime::now();
+
+    for path in paths {
         for entry in WalkDir::new(path)
             .min_depth(1)
             .follow_links(false)
             .into_iter()
-            .filter_map(|e| e.ok()) {
-                
-            if let Ok(metadata) = entry.metadata() {
-                if !metadata.is_file() {
-                    continue;
-                }
+            .filter_map(Result::ok)
+        {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
+            }
 
-                if let Ok(modified) = metadata.modified() {
-                    if let Ok(duration) = current_time.duration_since(modified) {
-                        let days_old = duration.as_secs() / 86400;
-                        
-                        match min_days_old {
-                            2 => if !(1..=2).contains(&days_old) { continue; },
-                            5 => if !(3..=5).contains(&days_old) { continue; },
-                            6 => if days_old < 6 { continue; },
-                            _ => continue,
-                        }
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+            let Ok(age) = current_time.duration_since(modified) else {
+                continue;
+            };
+            let days_old = age.as_secs() / 86400;
 
-                        match fs::remove_file(entry.path()) {
-                            Ok(_) => {
-                                stats.files_deleted += 1;
-                                stats.bytes_freed += metadata.len();
-                            },
-                            Err(e) => {
-                                stats.errors.push(format!(
-                                    "Failed to delete {}: {}",
-                                    entry.path().display(),
-                                    e
-                                ));
-                            }
-                        }
-                    }
+            match min_days_old {
+                2 => if !(1..=2).contains(&days_old) { continue; },
+                5 => if !(3..=5).contains(&days_old) { continue; },
+                6 => if days_old < 6 { continue; },
+                _ => continue,
+            }
+
+            match fs::remove_file(entry.path()) {
+                Ok(()) => {
+                    stats.files_deleted += 1;
+                    stats.bytes_freed = stats.bytes_freed.saturating_add(metadata.len());
                 }
+                Err(e) => stats.record_error(format!(
+                    "Failed to delete {}: {e}",
+                    entry.path().display()
+                )),
             }
         }
     }
 
     stats
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_roots_drops_missing_paths() {
+        let roots = dedup_roots(vec![PathBuf::from("/nonexistent/temp/path")]);
+        assert_eq!(roots, Vec::<PathBuf>::new());
+    }
+
+    #[test]
+    fn dedup_roots_collapses_repeated_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+
+        let roots = dedup_roots(vec![path.clone(), path.clone()]);
+
+        assert_eq!(roots, vec![path.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn dedup_roots_keeps_only_the_outermost_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().canonicalize().unwrap();
+        let child = parent.join("nested");
+        fs::create_dir(&child).unwrap();
+
+        assert_eq!(dedup_roots(vec![parent.clone(), child.clone()]), vec![parent.clone()]);
+        assert_eq!(dedup_roots(vec![child, parent.clone()]), vec![parent]);
+    }
+
+    #[test]
+    fn dedup_roots_keeps_unrelated_directories() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let first_path = first.path().canonicalize().unwrap();
+        let second_path = second.path().canonicalize().unwrap();
+
+        let roots = dedup_roots(vec![first_path.clone(), second_path.clone()]);
+
+        assert_eq!(roots, vec![first_path, second_path]);
+    }
+
+    #[test]
+    fn recorded_errors_are_capped() {
+        let mut stats = TempCleanupStats::default();
+
+        for i in 0..MAX_REPORTED_ERRORS + 10 {
+            stats.record_error(format!("failure {i}"));
+        }
+
+        assert_eq!(stats.errors.len(), MAX_REPORTED_ERRORS);
+        assert_eq!(stats.errors_omitted, 10);
+        assert_eq!(stats.errors.last().unwrap(), "failure 49");
+    }
+
+    #[test]
+    fn deleting_from_missing_path_reports_nothing() {
+        let stats = delete_temp_files(&[PathBuf::from("/nonexistent/temp/path")], 6);
+        assert_eq!(stats, TempCleanupStats::default());
+    }
+
+    #[test]
+    fn recent_files_are_not_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("fresh.tmp");
+        fs::write(&file, b"data").unwrap();
+
+        let stats = delete_temp_files(&[dir.path().to_path_buf()], 6);
+
+        assert_eq!(stats, TempCleanupStats::default());
+        assert!(file.exists());
+    }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -6,9 +6,9 @@ use core_foundation::dictionary::CFDictionary;
 use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
-use core_foundation_sys::base::{CFRelease, CFTypeRef};
+use core_foundation_sys::base::{CFGetTypeID, CFRelease, CFTypeRef};
 use core_foundation_sys::dictionary::CFDictionaryRef;
-use core_foundation_sys::string::CFStringRef;
+use core_foundation_sys::string::{CFStringGetTypeID, CFStringRef};
 
 type IOHIDEventSystemClientRef = *mut c_void;
 type IOHIDServiceClientRef = *mut c_void;
@@ -110,6 +110,10 @@ unsafe fn service_name(service: IOHIDServiceClientRef) -> Option<String> {
     let key = CFString::new("Product");
     let value = IOHIDServiceClientCopyProperty(service, key.as_concrete_TypeRef());
     if value.is_null() {
+        return None;
+    }
+    if CFGetTypeID(value) != CFStringGetTypeID() {
+        CFRelease(value);
         return None;
     }
     let name = CFString::wrap_under_create_rule(value as CFStringRef).to_string();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::time::{SystemTime, Instant};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MetricsScope {
     Full,
+    Summary,
     Light,
 }
 
@@ -52,11 +53,14 @@ pub struct ProcessMetrics {
     pub disk_usage: u64,
 }
 
+#[derive(Debug, Default, PartialEq)]
 pub struct TempFileMetrics {
     pub total_size: u64,
+    pub file_count: usize,
     pub files: Vec<TempFileInfo>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct TempFileInfo {
     pub path: String,
     pub size: u64,

--- a/src/types.rs
+++ b/src/types.rs
@@ -80,6 +80,7 @@ pub struct UsageTrend {
     pub pattern: f64,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct NetworkTrend {
     pub rx_rate: f64,
     pub tx_rate: f64,


### PR DESCRIPTION
Audit of unbounded memory retention across the codebase, plus a pass over the unsafe IOKit FFI.

## Fixes

**Temp file listings retained per sample.** `run_monitor` collected `MetricsScope::Full` for every sample, so each of the 6 default samples walked `$TMPDIR`, `/tmp` and `/var/tmp` in full and kept a `TempFileInfo` (owned path `String`) for every file found — all held alive in `metrics_history` for the whole run. Only the last sample's total size and count were ever displayed. Added `MetricsScope::Summary`, which totals size and count without retaining any listing, and `run_monitor` now uses `Light` for all samples but the last. That is one filesystem walk per run instead of six, and zero retained paths.

**Duplicate temp roots.** `$TMPDIR`, `/tmp` and `/var/tmp` were scanned as given, so overlapping or symlinked roots (`TMPDIR=/tmp`, `/tmp` → `/private/tmp`) were walked twice and double-counted. `temp_manager::temp_roots` now canonicalizes candidates and drops duplicates and nested children. The Windows `%USERPROFILE%\AppData\Local\Temp` candidate is `cfg`-gated instead of being formatted into a bogus path on Unix.

**Unbounded cleanup error list.** `delete_temp_files` pushed one `String` per failed unlink with no cap; a permission-denied-heavy tree could accumulate an error per file and print all of them. Errors are now capped at 50, with the remainder counted in `errors_omitted`.

**`show-temp-files` built the whole system.** It called `System::new_all()` plus full metric collection — process list, disks, and the retrying IOKit temperature read — to print a temp file listing. It now collects only temp files.

**IOKit FFI.** Audited the CoreFoundation ownership in `temperature.rs`: the client, service array, property value and event are each released on every path, including the early returns. One soundness hole: the `Product` property was passed to `CFString::wrap_under_create_rule` without checking its type. Now guarded with `CFGetTypeID`, releasing and skipping on mismatch.

Also clamped `sample_interval_secs` and the derived sample count to at least 1 — a config of `sample_interval_secs = 0` divided by zero, and a zero sample count panicked in `analyze_cpu_trend`.

## Verification

- 46 tests pass (was 36), clippy clean with `-D warnings`.
- `monitor` output is byte-identical before and after on the same machine (734.66 MiB / 2613 files), and the run does one temp walk instead of five.