### PR TITLE
Resolve the robustness findings from the v0.4.2 leak audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,10 @@ dirs = "5"
 notify-rust = "4"
 log = "0.4"
 env_logger = "0.11"
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/README.MD
+++ b/README.MD
@@ -76,7 +76,7 @@ git clone https://github.com/miky-rola/system-monitor && cd system-monitor && ca
 ```bash
 system-monitor                  # Full system report (30s collection)
 system-monitor daemon           # Background monitor with notifications
-system-monitor show-temp-files  # List temp files with sizes and ages
+system-monitor show-temp-files  # List the 500 largest temp files with sizes and ages
 system-monitor clean-temp       # Interactively clean temp files by age
 system-monitor config           # Show config path and current settings
 ```

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,7 +1,11 @@
 use crate::types::{SystemMetrics, UsageTrend, NetworkTrend, };
 
 pub fn analyze_cpu_trend(metrics_history: &[SystemMetrics]) -> Vec<UsageTrend> {
-    let cpu_count = metrics_history[0].cpu_usage.len();
+    let Some(first) = metrics_history.first() else {
+        return Vec::new();
+    };
+
+    let cpu_count = first.cpu_usage.len();
     let mut trends = Vec::with_capacity(cpu_count);
 
     for core in 0..cpu_count {
@@ -24,6 +28,10 @@ pub fn analyze_cpu_trend(metrics_history: &[SystemMetrics]) -> Vec<UsageTrend> {
 }
 
 pub fn analyze_memory_trend(metrics_history: &[SystemMetrics]) -> UsageTrend {
+    if metrics_history.is_empty() {
+        return UsageTrend { average: 0.0, peak: 0.0, pattern: 0.0 };
+    }
+
     let usages: Vec<u64> = metrics_history.iter()
         .map(|m| m.memory_usage)
         .collect();
@@ -129,6 +137,35 @@ mod tests {
                 components: HashMap::new(),
             },
         }
+    }
+
+    #[test]
+    fn cpu_trend_is_empty_for_empty_history() {
+        assert_eq!(analyze_cpu_trend(&[]), Vec::<UsageTrend>::new());
+    }
+
+    #[test]
+    fn cpu_trend_has_one_entry_per_core() {
+        assert_eq!(
+            analyze_cpu_trend(&[make_metrics(0, 0)]),
+            vec![UsageTrend { average: 10.0, peak: 10.0, pattern: 0.0 }]
+        );
+    }
+
+    #[test]
+    fn memory_trend_is_zero_for_empty_history() {
+        assert_eq!(
+            analyze_memory_trend(&[]),
+            UsageTrend { average: 0.0, peak: 0.0, pattern: 0.0 }
+        );
+    }
+
+    #[test]
+    fn memory_trend_reports_a_single_sample() {
+        assert_eq!(
+            analyze_memory_trend(&[make_metrics(0, 0)]),
+            UsageTrend { average: 50.0, peak: 50.0, pattern: 0.0 }
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,5 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::time::Duration;
 use sysinfo::{System, SystemExt};
 use crate::config::Config;
@@ -8,12 +7,23 @@ use crate::notifications::NotificationManager;
 use crate::security::{perform_security_analysis, generate_recommendations};
 use crate::types::{MetricsScope, SystemMetrics};
 
+enum LoopControl {
+    Continue,
+    Stop,
+}
+
+fn wait_for_shutdown(shutdown: &Receiver<()>, timeout: Duration) -> LoopControl {
+    match shutdown.recv_timeout(timeout) {
+        Ok(()) | Err(RecvTimeoutError::Disconnected) => LoopControl::Stop,
+        Err(RecvTimeoutError::Timeout) => LoopControl::Continue,
+    }
+}
+
 pub fn run_daemon(config: &Config) {
-    let running = Arc::new(AtomicBool::new(true));
-    let running_clone = running.clone();
+    let (signal_sender, shutdown) = mpsc::channel();
 
     ctrlc::set_handler(move || {
-        running_clone.store(false, Ordering::SeqCst);
+        let _ = signal_sender.send(());
     })
     .expect("Failed to set signal handler");
 
@@ -37,7 +47,7 @@ pub fn run_daemon(config: &Config) {
     let max_history = 10;
     let mut metrics_history: Vec<SystemMetrics> = Vec::with_capacity(max_history);
 
-    while running.load(Ordering::SeqCst) {
+    loop {
         sys.refresh_all();
         let metrics = collect_system_metrics(&mut sys, MetricsScope::Light);
 
@@ -68,7 +78,10 @@ pub fn run_daemon(config: &Config) {
             log::info!("Recommendation: {rec}");
         }
 
-        std::thread::sleep(interval);
+        match wait_for_shutdown(&shutdown, interval) {
+            LoopControl::Stop => break,
+            LoopControl::Continue => {}
+        }
     }
 
     println!("Daemon stopped.");
@@ -100,6 +113,39 @@ mod tests {
                 components: HashMap::new(),
             },
         }
+    }
+
+    #[test]
+    fn a_signal_stops_the_loop_without_waiting_for_the_interval() {
+        let (sender, receiver) = mpsc::channel();
+        sender.send(()).unwrap();
+
+        let waited = Instant::now();
+        let control = wait_for_shutdown(&receiver, Duration::from_secs(60));
+
+        assert!(matches!(control, LoopControl::Stop));
+        assert!(waited.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn a_dropped_sender_stops_the_loop() {
+        let (sender, receiver) = mpsc::channel::<()>();
+        drop(sender);
+
+        assert!(matches!(
+            wait_for_shutdown(&receiver, Duration::from_secs(60)),
+            LoopControl::Stop
+        ));
+    }
+
+    #[test]
+    fn the_loop_continues_when_no_signal_arrives() {
+        let (_sender, receiver) = mpsc::channel::<()>();
+
+        assert!(matches!(
+            wait_for_shutdown(&receiver, Duration::from_millis(10)),
+            LoopControl::Continue
+        ));
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -75,7 +75,11 @@ pub fn display_temp_files(temp_files: &TempFileMetrics) {
     println!("Total Files: {}", temp_files.file_count);
 
     if !temp_files.files.is_empty() {
-        println!("\nAll Temporary Files:");
+        if temp_files.files_omitted == 0 {
+            println!("\nAll Temporary Files:");
+        } else {
+            println!("\nLargest {} Temporary Files:", temp_files.files.len());
+        }
         println!("{:<10} {:<20} Path", "Size", "Last Modified");
         println!("{:-<80}", "");
         
@@ -103,11 +107,15 @@ pub fn display_temp_files(temp_files: &TempFileMetrics) {
                 })
                 .unwrap_or_else(|| "unknown".to_string());
 
-            println!("{:<10} {:<20} {}", 
+            println!("{:<10} {:<20} {}",
                 format_size(file.size, BINARY),
                 last_modified,
                 file.path
             );
+        }
+
+        if temp_files.files_omitted > 0 {
+            println!("...and {} more files not shown", temp_files.files_omitted);
         }
     }
 }
@@ -136,11 +144,12 @@ pub fn display_performance_analysis(metrics_history: &[SystemMetrics]) {
              format_size(network_trend.rx_rate as u64, BINARY),
              format_size(network_trend.tx_rate as u64, BINARY));
 
-    let latest_metrics = metrics_history.last().unwrap();
-    println!("\nTemporary Files Summary:");
-    println!("Total Size: {}", format_size(latest_metrics.temp_files.total_size, BINARY));
-    println!("Total Files: {}", latest_metrics.temp_files.file_count);
-    println!("Use 'show-temp-files' command to view detailed listing");
+    if let Some(latest_metrics) = metrics_history.last() {
+        println!("\nTemporary Files Summary:");
+        println!("Total Size: {}", format_size(latest_metrics.temp_files.total_size, BINARY));
+        println!("Total Files: {}", latest_metrics.temp_files.file_count);
+        println!("Use 'show-temp-files' command to view detailed listing");
+    }
 }
 
 pub fn display_security_analysis(analysis: &SecurityAnalysis) {    

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use display::{
     display_process_summary
 };
 use security::{perform_security_analysis, generate_recommendations};
-use temp_manager::delete_temp_files;
+use temp_manager::{delete_temp_files, TempFileAge};
 use humansize::{format_size, BINARY};
 
 #[derive(Parser)]
@@ -57,7 +57,7 @@ enum Commands {
     Config,
 }
 
-fn prompt_temp_file_age() -> Option<u64> {
+fn prompt_temp_file_age() -> Option<TempFileAge> {
     println!("\nChoose files to delete based on age:");
     println!("1. Recent files (1-2 days old)");
     println!("2. Moderately old files (3-5 days old)");
@@ -73,15 +73,15 @@ fn prompt_temp_file_age() -> Option<u64> {
     match input.trim() {
         "1" => {
             println!("Deleting files 1-2 days old...");
-            Some(2)
+            Some(TempFileAge::Recent)
         }
         "2" => {
             println!("Deleting files 3-5 days old...");
-            Some(5)
+            Some(TempFileAge::Moderate)
         }
         "3" => {
             println!("Deleting files 6+ days old...");
-            Some(6)
+            Some(TempFileAge::Old)
         }
         "4" => {
             println!("Cleanup cancelled.");
@@ -106,8 +106,22 @@ fn prompt_apply_coolant(temp: f32, threshold: f64) -> bool {
 
 fn run_monitor(cfg: &config::Config) {
     let monitoring_duration = Duration::from_secs(cfg.monitoring.duration_secs);
+    if cfg.monitoring.sample_interval_secs == 0 {
+        log::warn!("monitoring.sample_interval_secs is 0; sampling every 1s instead");
+    }
+
     let sample_interval = Duration::from_secs(cfg.monitoring.sample_interval_secs.max(1));
-    let samples = ((monitoring_duration.as_secs() / sample_interval.as_secs()) as usize).max(1);
+    let samples = (monitoring_duration.as_secs() / sample_interval.as_secs()) as usize;
+    if samples == 0 {
+        log::warn!(
+            "monitoring.duration_secs ({}) is shorter than the {}s sample interval; \
+             collecting a single sample, so trends and network throughput will be degenerate",
+            monitoring_duration.as_secs(),
+            sample_interval.as_secs(),
+        );
+    }
+
+    let samples = samples.max(1);
 
     let mut sys = System::new_all();
     #[cfg(target_os = "macos")]
@@ -216,13 +230,12 @@ fn run_show_temp_files() {
 }
 
 fn run_clean_temp() {
-    let days_threshold = match prompt_temp_file_age() {
-        Some(days) => days,
-        None => return,
+    let Some(age) = prompt_temp_file_age() else {
+        return;
     };
 
     println!("\nCleaning temporary files...");
-    let stats = delete_temp_files(&temp_manager::temp_roots(), days_threshold);
+    let stats = delete_temp_files(&temp_manager::temp_roots(), age);
 
     println!("\nCleanup Results:");
     println!("Files Deleted: {}", stats.files_deleted);
@@ -240,6 +253,11 @@ fn run_clean_temp() {
 }
 
 fn main() {
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let cli = Cli::parse();
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,8 +1,12 @@
 use walkdir::WalkDir;
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::path::PathBuf;
+use std::time::SystemTime;
 use sysinfo::{System, SystemExt, ProcessExt, DiskExt, CpuExt, NetworkExt, NetworksExt, ComponentExt};
 use crate::types::{SystemMetrics, DiskMetrics, ProcessMetrics, TempFileMetrics, TempFileInfo, TemperatureMetrics, TemperatureReading, MetricsScope};
+
+const MAX_LISTED_TEMP_FILES: usize = 500;
 
 pub fn collect_system_metrics(sys: &mut System, scope: MetricsScope) -> SystemMetrics {
     let temp_files = collect_temp_files(scope);
@@ -139,6 +143,7 @@ fn scan_temp_roots(roots: &[PathBuf], scope: MetricsScope) -> TempFileMetrics {
     }
 
     let mut metrics = TempFileMetrics::default();
+    let mut largest: BinaryHeap<Reverse<(u64, String, Option<SystemTime>)>> = BinaryHeap::new();
 
     for root in roots {
         for entry in WalkDir::new(root)
@@ -159,17 +164,44 @@ fn scan_temp_roots(roots: &[PathBuf], scope: MetricsScope) -> TempFileMetrics {
             metrics.file_count += 1;
 
             match scope {
-                MetricsScope::Full => metrics.files.push(TempFileInfo {
-                    path: entry.path().to_string_lossy().into_owned(),
-                    size,
-                    last_modified: metadata.modified().ok(),
-                }),
+                MetricsScope::Full => {
+                    let smallest_listed = match largest.peek() {
+                        Some(Reverse((listed_size, _, _))) => *listed_size,
+                        None => 0,
+                    };
+                    if largest.len() == MAX_LISTED_TEMP_FILES {
+                        if smallest_listed >= size {
+                            continue;
+                        }
+                        largest.pop();
+                    }
+
+                    largest.push(Reverse((
+                        size,
+                        entry.path().to_string_lossy().into_owned(),
+                        metadata.modified().ok(),
+                    )));
+                }
                 MetricsScope::Summary | MetricsScope::Light => {}
             }
         }
     }
 
-    metrics.files.sort_by_key(|file| std::cmp::Reverse(file.size));
+    match scope {
+        MetricsScope::Full => {
+            metrics.files_omitted = metrics.file_count - largest.len();
+            metrics.files = largest
+                .into_sorted_vec()
+                .into_iter()
+                .map(|Reverse((size, path, last_modified))| TempFileInfo {
+                    path,
+                    size,
+                    last_modified,
+                })
+                .collect();
+        }
+        MetricsScope::Summary | MetricsScope::Light => {}
+    }
 
     metrics
 }
@@ -248,6 +280,7 @@ mod tests {
                 total_size: 110,
                 file_count: 2,
                 files: Vec::new(),
+                files_omitted: 0,
             }
         );
     }
@@ -260,10 +293,35 @@ mod tests {
 
         assert_eq!(metrics.total_size, 110);
         assert_eq!(metrics.file_count, 2);
+        assert_eq!(metrics.files_omitted, 0);
         assert_eq!(
             metrics.files.iter().map(|file| file.size).collect::<Vec<_>>(),
             vec![100, 10]
         );
         assert!(metrics.files[0].path.ends_with("large.tmp"));
+    }
+
+    #[test]
+    fn full_scope_lists_only_the_largest_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_count = MAX_LISTED_TEMP_FILES + 10;
+        for size in 1..=file_count {
+            std::fs::write(dir.path().join(format!("{size}.tmp")), vec![0u8; size]).unwrap();
+        }
+
+        let metrics = scan_temp_roots(&[dir.path().to_path_buf()], MetricsScope::Full);
+
+        assert_eq!(metrics.file_count, file_count);
+        assert_eq!(metrics.total_size, (file_count * (file_count + 1) / 2) as u64);
+        assert_eq!(metrics.files.len(), MAX_LISTED_TEMP_FILES);
+        assert_eq!(metrics.files_omitted, 10);
+        assert_eq!(
+            metrics.files.iter().map(|file| file.size).collect::<Vec<_>>(),
+            (1..=file_count)
+                .rev()
+                .take(MAX_LISTED_TEMP_FILES)
+                .map(|size| size as u64)
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/temp_manager.rs
+++ b/src/temp_manager.rs
@@ -4,6 +4,23 @@ use walkdir::WalkDir;
 
 const MAX_REPORTED_ERRORS: usize = 50;
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TempFileAge {
+    Recent,
+    Moderate,
+    Old,
+}
+
+impl TempFileAge {
+    pub fn includes(self, days_old: u64) -> bool {
+        match self {
+            Self::Recent => (1..=2).contains(&days_old),
+            Self::Moderate => (3..=5).contains(&days_old),
+            Self::Old => days_old >= 6,
+        }
+    }
+}
+
 #[derive(Debug, Default, PartialEq)]
 pub struct TempCleanupStats {
     pub files_deleted: usize,
@@ -62,7 +79,7 @@ fn dedup_roots(candidates: Vec<PathBuf>) -> Vec<PathBuf> {
     roots
 }
 
-pub fn delete_temp_files(paths: &[PathBuf], min_days_old: u64) -> TempCleanupStats {
+pub fn delete_temp_files(paths: &[PathBuf], age: TempFileAge) -> TempCleanupStats {
     let mut stats = TempCleanupStats::default();
     let current_time = std::time::SystemTime::now();
 
@@ -83,16 +100,13 @@ pub fn delete_temp_files(paths: &[PathBuf], min_days_old: u64) -> TempCleanupSta
             let Ok(modified) = metadata.modified() else {
                 continue;
             };
-            let Ok(age) = current_time.duration_since(modified) else {
+            let Ok(modified_ago) = current_time.duration_since(modified) else {
                 continue;
             };
-            let days_old = age.as_secs() / 86400;
+            let days_old = modified_ago.as_secs() / 86400;
 
-            match min_days_old {
-                2 => if !(1..=2).contains(&days_old) { continue; },
-                5 => if !(3..=5).contains(&days_old) { continue; },
-                6 => if days_old < 6 { continue; },
-                _ => continue,
+            if !age.includes(days_old) {
+                continue;
             }
 
             match fs::remove_file(entry.path()) {
@@ -114,6 +128,8 @@ pub fn delete_temp_files(paths: &[PathBuf], min_days_old: u64) -> TempCleanupSta
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn dedup_roots_drops_missing_paths() {
@@ -168,8 +184,71 @@ mod tests {
     }
 
     #[test]
+    fn age_brackets_cover_every_day_count_exactly_once() {
+        let brackets = |days_old| {
+            [TempFileAge::Recent, TempFileAge::Moderate, TempFileAge::Old]
+                .into_iter()
+                .filter(|age| age.includes(days_old))
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(brackets(0), Vec::<TempFileAge>::new());
+        assert_eq!(brackets(1), vec![TempFileAge::Recent]);
+        assert_eq!(brackets(2), vec![TempFileAge::Recent]);
+        assert_eq!(brackets(3), vec![TempFileAge::Moderate]);
+        assert_eq!(brackets(5), vec![TempFileAge::Moderate]);
+        assert_eq!(brackets(6), vec![TempFileAge::Old]);
+        assert_eq!(brackets(100), vec![TempFileAge::Old]);
+    }
+
+    fn aged_file(dir: &Path, name: &str, days_old: u64) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"data").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(SystemTime::now() - Duration::from_secs(days_old * 86400 + 3600))
+            .unwrap();
+        path
+    }
+
+    #[test]
+    fn each_bracket_deletes_only_its_own_files() {
+        for (age, expected_survivors) in [
+            (TempFileAge::Recent, ["moderate.tmp", "old.tmp"]),
+            (TempFileAge::Moderate, ["old.tmp", "recent.tmp"]),
+            (TempFileAge::Old, ["moderate.tmp", "recent.tmp"]),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            aged_file(dir.path(), "recent.tmp", 1);
+            aged_file(dir.path(), "moderate.tmp", 4);
+            aged_file(dir.path(), "old.tmp", 9);
+
+            let stats = delete_temp_files(&[dir.path().to_path_buf()], age);
+
+            assert_eq!(
+                stats,
+                TempCleanupStats {
+                    files_deleted: 1,
+                    bytes_freed: 4,
+                    errors: Vec::new(),
+                    errors_omitted: 0,
+                }
+            );
+
+            let mut survivors: Vec<String> = fs::read_dir(dir.path())
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
+            survivors.sort();
+            assert_eq!(survivors, expected_survivors);
+        }
+    }
+
+    #[test]
     fn deleting_from_missing_path_reports_nothing() {
-        let stats = delete_temp_files(&[PathBuf::from("/nonexistent/temp/path")], 6);
+        let stats = delete_temp_files(&[PathBuf::from("/nonexistent/temp/path")], TempFileAge::Old);
         assert_eq!(stats, TempCleanupStats::default());
     }
 
@@ -179,7 +258,7 @@ mod tests {
         let file = dir.path().join("fresh.tmp");
         fs::write(&file, b"data").unwrap();
 
-        let stats = delete_temp_files(&[dir.path().to_path_buf()], 6);
+        let stats = delete_temp_files(&[dir.path().to_path_buf()], TempFileAge::Old);
 
         assert_eq!(stats, TempCleanupStats::default());
         assert!(file.exists());

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,7 @@ pub struct TempFileMetrics {
     pub total_size: u64,
     pub file_count: usize,
     pub files: Vec<TempFileInfo>,
+    pub files_omitted: usize,
 }
 
 #[derive(Debug, PartialEq)]
@@ -74,6 +75,7 @@ pub struct SecurityAnalysis {
     pub swap_pressure: Vec<String>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct UsageTrend {
     pub average: f64,
     pub peak: f64,


### PR DESCRIPTION
Fixes all six findings from the v0.4.2 leak audit. Each file is its own commit.

### 1. Piping any listing command into `head` panics
`main` now restores the default `SIGPIPE` disposition on Unix, so the process is killed by the signal instead of `println!` panicking on `EPIPE`. Fixes every output path at once — `show-temp-files`, `monitor | less`, `config | head`. Adds `libc` as a direct dependency (already in the tree via `sysinfo`).

### 2. `analyze_cpu_trend` / `analyze_memory_trend` panicked on empty history
Both now return an empty/zeroed result, matching the guard `analyze_network_trend` already had. `display_performance_analysis` had the same latent `last().unwrap()`, now guarded. `UsageTrend` derives `Debug`/`PartialEq` so the new tests assert on whole structs.

### 3. `delete_temp_files` silently deleted nothing for unexpected age values
Replaced the `2`/`5`/`6` magic day counts and their wildcard arm with `TempFileAge { Recent, Moderate, Old }`, which carries its own range via `TempFileAge::includes`. The unrepresentable case is gone. New tests cover the bracket boundaries and a real end-to-end delete of aged files, asserting each bracket removes only its own.

### 4. Daemon took up to `check_interval_secs` to stop, and ignored SIGTERM
`ctrlc` now uses the `termination` feature (SIGTERM/SIGHUP alongside SIGINT), and the `AtomicBool` + unconditional `thread::sleep` is replaced by an mpsc channel the handler sends on, awaited with `recv_timeout`. Shutdown is immediate rather than polled. `wait_for_shutdown` is unit-tested for signal / dropped-sender / timeout.

Verified against the release binary: `kill -TERM` on a 60s-interval daemon prints `Daemon stopped.` within a second; `kill -INT` likewise.

### 5. Invalid monitoring config was silently clamped
`run_monitor` keeps the `.max(1)` clamps but now emits a `log::warn!` when either fires — a zero sample interval, or a `duration_secs` shorter than the interval producing a single degenerate sample.

### 6. `show-temp-files` held the entire listing in memory
The `Full` scope now keeps a bounded min-heap of the 500 largest files, allocating the path only for entries that make the cut. Totals and counts still cover every file, and the display prints `...and N more files not shown`. On my machine: 500 listed, 92,163 omitted, largest-first ordering preserved.

Closes #8
